### PR TITLE
Replace (r) sign in README with Unicode character

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 
 ## Getting Started
 
-- Clone the repository and open JustDecompileEngine.sln in Microsoft (r) Visual Studio (r).
+- Clone the repository and open JustDecompileEngine.sln in Microsoft® Visual Studio®.
 - Set your startup project to ConsoleRunner.
 - Enjoy
 


### PR DESCRIPTION
I think it would be visually better if the [actual unicode symbol](http://www.fileformat.info/info/unicode/char/ae/index.htm) for a registered trademark was used instead of ```(r)```. 
Even most terminal-based text editors nowadays support Unicode, so this should not be a problem.