### PR TITLE
Use Stopwatch for timing, not DateTime

### DIFF
--- a/JustDecompileCmdShell/CmdShell.cs
+++ b/JustDecompileCmdShell/CmdShell.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -149,9 +150,9 @@ namespace JustDecompileCmdShell
             MSBuildProjectBuilder projectBuilder = GetProjectBuilder(assembly, projectInfo, settings, projectInfo.Language, projFilePath, preferences, frameworkResolver);
             ConfigurateProjectBuilder(projectBuilder);
 
-            DateTime startTime = DateTime.Now;
+            Stopwatch stopwatch = Stopwatch.StartNew();
             projectBuilder.BuildProject();
-            TimeSpan projectGenerationTime = DateTime.Now - startTime;
+            TimeSpan projectGenerationTime = stopwatch.Elapsed;
             return projectGenerationTime;
         }
 


### PR DESCRIPTION
Timing operations should always be done with a `System.Diagnostics.Stopwatch`.

Using `DateTime.Now` is undesirable because:

- The system clock is not very precise (RTC vs QPC).
- The system clock can drift.
- The system clock can be adjusted automatically via NTP sync, or manually by the user.
- `DateTime.Now` is based on the computer's local time zone, which may lead to errors if the timing operation crosses a daylight saving time transition.