### PR TITLE
Escape namespace with GlobalKeyword collision

### DIFF
--- a/Cecil.Decompiler/Decompiler/Utilities.cs
+++ b/Cecil.Decompiler/Decompiler/Utilities.cs
@@ -507,6 +507,30 @@ namespace Telerik.JustDecompiler.Decompiler
 			return result;
 		}
 
+		public static string EscapeNamespace(string @namespace, ILanguage language)
+		{
+			StringBuilder sb = new StringBuilder();
+			bool changed = false;
+			foreach (string part in @namespace.Split('.'))
+			{
+				string newPart = part;
+				if (!language.IsValidIdentifier(newPart))
+				{
+					newPart = language.ReplaceInvalidCharactersInIdentifier(newPart);
+					changed = true;
+				}
+				if (language.IsGlobalKeyword(newPart))
+				{
+					newPart = EscapeTypeName(newPart, language);
+					changed = true;
+				}
+				if (sb.Length > 0)
+					sb.Append(".");
+				sb.Append(newPart);
+			}
+			return changed ? sb.ToString() : @namespace;
+		}
+
 		public static bool IsInitializerPresent(InitializerExpression initializer)
 		{
 			return initializer != null && initializer.Expression != null && initializer.Expression.Expressions.Count > 0;

--- a/Cecil.Decompiler/Languages/NamespaceImperativeLanguageWriter.cs
+++ b/Cecil.Decompiler/Languages/NamespaceImperativeLanguageWriter.cs
@@ -176,7 +176,7 @@ namespace Telerik.JustDecompiler.Languages
 				{
 					namespaceName = ModuleContext.RenamedNamespacesMap[@namespace];
 				}
-				Write(namespaceName);
+				Write(Utilities.EscapeNamespace(namespaceName, Language));
 				WriteEndOfStatement();
 			}
 


### PR DESCRIPTION
Namespace imports with a part that matches a GlobalKeyword must be escaped,
For example `using ikvm.internal;` must be written as `using ikvm.@internal;`