### PR TITLE
Fixes Registry being statically referenced

### DIFF
--- a/Mono.Cecil/Mono.Cecil.AssemblyResolver/SystemInformation.cs
+++ b/Mono.Cecil/Mono.Cecil.AssemblyResolver/SystemInformation.cs
@@ -90,7 +90,9 @@ namespace Mono.Cecil.AssemblyResolver
         {
             get
             {
-                return Environment.GetEnvironmentVariable("windir") ?? Environment.GetEnvironmentVariable("SystemRoot");
+                return Environment.GetEnvironmentVariable("windir") 
+                       ?? Environment.GetEnvironmentVariable("SystemRoot")
+                       ?? string.Empty;
             }
         }
 
@@ -98,7 +100,9 @@ namespace Mono.Cecil.AssemblyResolver
         {
             get
             {
-                return Environment.GetEnvironmentVariable("ProgramFiles(x86)") ?? Environment.GetEnvironmentVariable("ProgramFiles");
+                return Environment.GetEnvironmentVariable("ProgramFiles(x86)") 
+                       ?? Environment.GetEnvironmentVariable("ProgramFiles")
+                       ?? string.Empty;
             }
         }
 
@@ -153,6 +157,7 @@ namespace Mono.Cecil.AssemblyResolver
         {
             get
             {
+                if (((int)Environment.OSVersion.Platform) >= 4) return null;
                 return (string)Registry.GetValue(Registry.LocalMachine.Name + @"\Software\Microsoft\Silverlight", "Version", null) ??
                     (string)Registry.GetValue(Registry.LocalMachine.Name + @"\Software\Wow6432Node\Microsoft\Silverlight", "Version", null);
             }

--- a/SystemInformationHelpers/Framework4VersionResolver.cs
+++ b/SystemInformationHelpers/Framework4VersionResolver.cs
@@ -81,6 +81,11 @@ namespace SystemInformationHelpers
             {
                 if (!installedFramework4Version.HasValue)
                 {
+                    if ((int) Environment.OSVersion.Platform >= 4)
+                    {
+                        installedFramework4Version = GetFrameworkVersionByFileVersion(GetCLRDefault32MscorlibPath());
+                        return installedFramework4Version.Value;
+                    }
                     try
                     {
                         RegistryKey ndpKey = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry32)


### PR DESCRIPTION
Update bits so that they do not immediately call Registry on non windows systems and when resolving paths do not yield null because Windows Environment variables are not set. 