### PR TITLE
Changing the attribute writer re. null literals.

### DIFF
--- a/Cecil.Decompiler/Languages/AttributeWriter.cs
+++ b/Cecil.Decompiler/Languages/AttributeWriter.cs
@@ -779,7 +779,7 @@ namespace Telerik.JustDecompiler.Languages
             }
             else
             {
-                if (argument.Type.Name != "Type" || argument.Type.Namespace != "System")
+                if (argument.Value == null || argument.Type.Name != "Type" || argument.Type.Namespace != "System")
                 {
                     genericWriter.WriteLiteralInLanguageSyntax(argument.Value);
                 }


### PR DESCRIPTION
Changing the attribute writers to write out null literals instead of passing through the typeof writer for System.Type-typed attribute constructor values. That should fix telerik/JustDecompileEngine#40.